### PR TITLE
Fix wrong window tile map selection

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -55,7 +55,7 @@ static void render_back(uint32_t *buf, uint8_t *addr_sp)
 
         y = addr_sp[0xff44];  // current line to update
         uint8_t *tile_map_ptr = addr_sp +
-                                ((addr_sp[0xff40] & 0x08) ? 0x9800 : 0x9c00) +
+                                ((addr_sp[0xff40] & 0x40) ? 0x9c00 : 0x9800) +
                                 (y - wy) / 8 * 32;
         uint8_t *tile_data_ptr =
             addr_sp + ((addr_sp[0xff40] & 0x10) ? 0x8000 : 0x9000);


### PR DESCRIPTION
I found that in function `render_back`, the selection of window tile map may be wrong. According to [gbdev - LCD Control Register](https://gbdev.gg8.se/wiki/articles/Video_Display#LCD_Control_Register) (I'm not sure if there's a more credible development manual?), window tile map should be select by bit 6 (LSB = 0) in LCDC register, 0 for low bank and 1 for high bank. 


