### PR TITLE
Correct the LCDY register update

### DIFF
--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -60,11 +60,11 @@ void update_ioregs(gb_state *state)
     if (state->inst_count > state->ly_count + 114) {
         state->ly_count = state->inst_count;
 
-        if (mem[0xff44] < 144)
-            update_line(mem);
-
         mem[0xff44]++;
-        mem[0xff44] %= 153;
+        mem[0xff44] %= 154;
+        
+	if (mem[0xff44] < 144)
+            update_line(mem);
 
         if (mem[0xff45] == mem[0xff44]) {
             /* Set the coincidence flag */


### PR DESCRIPTION
How LCDY(`0xff44`) was updated may include two error in the previous commit.

According to the development manual of Game Boy, the LCDY indicates the vertical line to which the present data is transferred
to the LCD Driver. It should range from 0 through 153, so we should reduce LCDY modulo 154.

Also, the function `update_line` should be called after updating the LCDY. If we update LCDY before `update_line`, the emulator may scroll the wrong scanline.

The following GIF image can show more information about this error. In the first GIF image, before we fix this, you can find that the bottom of the coin icon will scroll with the background. In the second GIF image, this is fix after the revised code.

![](https://i.imgur.com/Naux5L0.gif) 
![](https://i.imgur.com/mVirBo5.gif)