### PR TITLE
Add git pre-commit hook for format checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,11 @@ BIN = build/jitboy
 OBJS = core.o gbz80.o lcd.o memory.o emit.o interrupt.o main.o optimize.o
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps := $(OBJS:%.o=%.o.d)
+GIT_HOOKS := .git/hooks/applied
 
 all: CFLAGS += -O3
 all: LDFLAGS += -O3
-all: $(BIN)
+all: $(BIN) $(GIT_HOOKS)
 
 sanitizer: CFLAGS += -Og -g -fsanitize=thread
 sanitizer: LDFLAGS += -fsanitize=thread
@@ -37,6 +38,10 @@ sanitizer: $(BIN)
 debug: CFLAGS += -g -D DEBUG
 debug: DYNASMFLAGS += -D DEBUG
 debug: $(BIN)
+
+$(GIT_HOOKS):
+	@scripts/install-git-hooks
+	@echo
 
 $(BIN): $(OBJS)
 	$(CC) $(LDFLAGS) -o $@ $+ $(LIBS)

--- a/scripts/install-git-hooks
+++ b/scripts/install-git-hooks
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if ! test -d .git; then
+    echo "Execute scripts/install-git-hooks in the top-level directory."
+    exit 1
+fi
+
+ln -sf ../../scripts/pre-commit.hook .git/hooks/pre-commit || exit 1
+chmod +x .git/hooks/pre-commit
+
+touch .git/hooks/applied || exit 1
+
+echo
+echo "Git hooks are installed successfully."
+

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+RETURN=0
+CLANG_FORMAT=$(which clang-format)
+if [ $? -ne 0 ]; then
+    echo "[!] clang-format not installed. Unable to check source file format policy." >&2
+    exit 1
+fi
+
+DIFF=$(which colordiff)
+if [ $? -ne 0 ]; then
+     DIFF=diff
+fi
+
+FILES=`git diff --cached --name-only --diff-filter=ACMR | grep -E "\.(c|cpp|h)$"`
+for FILE in $FILES; do
+    nf=`git checkout-index --temp $FILE | cut -f 1`
+    tempdir=`mktemp -d` || exit 1
+    newfile=`mktemp ${tempdir}/${nf}.XXXXXX` || exit 1
+    basename=`basename $FILE`
+
+    source="${tempdir}/${basename}"
+    mv $nf $source
+    cp .clang-format $tempdir
+    $CLANG_FORMAT $source > $newfile 2>> /dev/null
+    $DIFF -u -p -B --label="modified $FILE" --label="expected coding style" \
+          "${source}" "${newfile}" 
+    r=$?
+    rm -rf "${tempdir}"
+    if [ $r != 0 ] ; then
+        echo "[!] $FILE does not follow the consistent coding style." >&2 
+        RETURN=1
+    fi  
+    if [ $RETURN -eq 1 ]; then
+        echo "" >&2
+        echo "Make sure you indent as the following:" >&2
+        echo "    clang-format -i $FILE" >&2
+        echo
+    fi
+done
+
+exit $RETURN                              


### PR DESCRIPTION
A simple git pre-commit hook for format checking is included. This can make sure all of our `*.c` or `*.h` files follow the rule in `.clang-format`