### PR TITLE
Improve synchronization for audio playback

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -19,6 +19,7 @@
 /* Memory referenced to register start from 0xFF10, and should access at most
  * 0xFF3F */
 static uint8_t *audio_mem;
+static gb_audio *g_audio;
 
 struct chan_len_ctr {
     unsigned load : 6;
@@ -497,10 +498,21 @@ void audio_init(gb_audio *audio, gb_memory *mem)
 
     /* reference */
     audio_mem = mem->mem + 0xFF10;
+    g_audio = audio;
 
     /* Initialize channels and samples */
     memset(chans, 0, sizeof(chans));
     chans[0].val = chans[1].val = -1;
 
     SDL_PauseAudioDevice(dev, 0);
+}
+
+void lock_audio_dev()
+{
+    SDL_LockAudioDevice(g_audio->dev);
+}
+
+void unlock_audio_dev()
+{
+    SDL_UnlockAudioDevice(g_audio->dev);
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -20,5 +20,7 @@ typedef struct {
 
 void audio_init(gb_audio *audio, gb_memory *mem);
 void channel_update(const uint16_t addr, const uint8_t val);
+void lock_audio_dev();
+void unlock_audio_dev();
 
 #endif

--- a/src/core.c
+++ b/src/core.c
@@ -108,8 +108,6 @@ bool run_vm(gb_vm *vm)
     uint16_t prev_pc = vm->state.last_pc;
     vm->state.last_pc = vm->state.pc;
 
-    SDL_LockAudioDevice(vm->audio.dev);
-
     /* compile next block / get cached block */
     if (vm->state.pc < 0x4000) { /* first block */
         if (vm->compiled_blocks[0][vm->state.pc].exec_count == 0) {
@@ -157,8 +155,6 @@ bool run_vm(gb_vm *vm)
         LOG_DEBUG("finished\n");
         free_block(&temp);
     }
-
-    SDL_UnlockAudioDevice(vm->audio.dev);
 
     LOG_DEBUG("ioregs: STAT=%02x LY=%02x IF=%02x IE=%02x\n",
               vm->memory.mem[0xff41], vm->memory.mem[0xff44],

--- a/src/memory.c
+++ b/src/memory.c
@@ -175,8 +175,10 @@ void gb_memory_write(gb_state *state, uint64_t addr, uint64_t value)
         LOG_DEBUG("Memory write to %#" PRIx64 ", value is %#" PRIx64 "\n", addr,
                   value);
 
+        lock_audio_dev();
         channel_update(addr, value);
         mem[addr] = value;
+        unlock_audio_dev();
     } else {
         LOG_DEBUG("Memory write to %#" PRIx64 ", value is %#" PRIx64 "\n", addr,
                   value);


### PR DESCRIPTION
In the previous jitboy, the audio device was locked during the whole block execution. However, the data race may just happen when operating on the memory region related to audio. It means that the code region we locked on before is larger than the true critical section. So this pull request is trying to fix this problem.