### PR TITLE
Close open SDL audio device when quit

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -306,5 +306,7 @@ bool free_vm(gb_vm *vm)
     /* destroy window */
     deinit_window(&vm->lcd);
 
+    SDL_CloseAudioDevice(vm->audio.dev);
+
     return gb_memory_free(&vm->memory);
 }


### PR DESCRIPTION
We should remember to close open audio devices once they are no longer needed.