### PR TITLE
Fix wrong implementation of ADD16

### DIFF
--- a/src/emit.dasc
+++ b/src/emit.dasc
@@ -566,6 +566,7 @@ static bool inst_inc16(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
 static bool inst_add16(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
 {
     | print "ADD16"
+    | mov byte state->f_subtract, 0 
     switch (inst->op1) {
     case REG_HL:
         | and xH, 0xff


### PR DESCRIPTION
According to [GameBoy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf), after running 16 bits add instruction, we should reset the negative / subtract flag back to zero. This error implementation is also found by the Game Boy instruction tester ([gbit](https://github.com/koenk/gbit)). Here's the error message:

```
  === STATE MISMATCH ===

 - Instruction -
ADD HL, BC

 - Input state -
 PC   SP   AF   BC   DE   HL  ZNHC hlt IME
0000 0000 00f0 0000 0000 0000 1111  0   0


 - Test-CPU output state -
 PC   SP   AF   BC   DE   HL  ZNHC hlt IME
0001 0000 0040 0000 0000 0000 0100  0   0


 - Correct output state -
 PC   SP   AF   BC   DE   HL  ZNHC hlt IME
0001 0000 0080 0000 0000 0000 1000  0   0
```
(Please ignore the gbit report for the incorrect flag of Z, H, C. Since they are not emulated but use the status flags of the host architecture for the emulated environment, I apply some trick to make gbit skip checking these flags. However, the outputs are not revised accordingly because they are not the important part. So the flag Z, H, C showed on gbit error messages are not the one on our emulator.)

After this pull request, the error can be fixed.