### PR TITLE
Support load and save features in emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OUT ?= build
 SHELL_HACK := $(shell mkdir -p $(OUT))
 
 BIN = build/jitboy
-OBJS = core.o gbz80.o lcd.o memory.o emit.o interrupt.o main.o optimize.o audio.o
+OBJS = core.o gbz80.o lcd.o memory.o emit.o interrupt.o main.o optimize.o audio.o save.o
 OBJS := $(addprefix $(OUT)/, $(OBJS))
 deps := $(OBJS:%.o=%.o.d)
 GIT_HOOKS := .git/hooks/applied

--- a/README.md
+++ b/README.md
@@ -583,6 +583,19 @@ The start of the `VBLANK` period is also used to limit the speed: If less than 1
 passed since the last `VBLANK`, there is a correspondingly long wait before the execution
 is continued.
 
+## State saving
+
+Some Game Boy cartridges include RAM inside. When inserting a cartridge with RAM, it will get 
+mapped at `0xA000`-`0xBFFF` in Game Boy Memory Management Unit. The RAM in the cartridge is 
+stored in battery-backed memory, allowing to save game state like high score tables or 
+character's position. So even if the Game Boy is turned off, we can still return to the state 
+when opening it next time.
+
+When opening jitboy, the emulator will try to find a file containing the suffix `sav` to the 
+end of ROM name. If it exists, every byte in the file will be copied to the RAM banks. Since 
+one of these RAM banks would be chosen to mapped at `0xA000` to `0xBFFF` by MBC, the saving 
+state can be restored. When closing jitboy, contents in RAM banks should be copied to the file 
+with the name we mentioned before.
 
 ## Build
 

--- a/src/core.c
+++ b/src/core.c
@@ -3,6 +3,7 @@
 
 #include "core.h"
 #include "interrupt.h"
+#include "save.h"
 
 void free_block(gb_block *block)
 {
@@ -83,6 +84,9 @@ bool init_vm(gb_vm *vm, const char *filename, int opt_level, bool init_io)
         vm->highmem_blocks[i].exec_count = 0;
         vm->highmem_blocks[i].func = 0;
     }
+
+    if (!read_battery(vm->memory.savname, &vm->memory))
+        LOG_ERROR("Fail to read battery\n");
 
     if (init_io) {
         /* both audio and lcd will be initialized if init_io is true*/

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include "core.h"
+#include "save.h"
 
 static void usage(const char *exe)
 {
@@ -164,6 +165,10 @@ int main(int argc, char *argv[])
 
 end_program:
     LOG_DEBUG("terminating ...\n");
+
+    if (!write_battery(vm->memory.savname, &vm->memory)) {
+        LOG_DEBUG("Failed to save battery\n");
+    }
 
     free_vm(vm);
     free(vm);

--- a/src/memory.h
+++ b/src/memory.h
@@ -8,6 +8,8 @@ typedef struct {
     uint8_t *mem;
     uint8_t *ram_banks;
     const char *filename;
+    char *savname;
+    uint8_t max_ram_banks_num;
     int fd;
     enum {
         MBC_NONE = 0x00,
@@ -80,6 +82,9 @@ typedef struct {
         REASON_RET = 8
     } trap_reason;
 } gb_state;
+
+/* flush back external RAM(0xa000 - 0xbfff) to ram_banks buffer */
+void gb_memory_ram_flush(gb_memory *mem);
 
 /* emulate write through mbc */
 void gb_memory_write(gb_state *state, uint64_t addr, uint64_t value);

--- a/src/save.c
+++ b/src/save.c
@@ -1,0 +1,57 @@
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "memory.h"
+
+bool read_battery(char *savfile, gb_memory *mem)
+{
+    if (!savfile)
+        return false;
+
+    FILE *fp = fopen(savfile, "rb");
+
+    if (!fp) {
+        LOG_ERROR("Fail to open file %s\n", savfile);
+        return false;
+    }
+
+    /* get file size and allocate size accordingly */
+    fseek(fp, 0, SEEK_END);
+    size_t sz = ftell(fp) * sizeof(uint8_t);
+    rewind(fp);
+
+    size_t read_size = fread(mem->ram_banks, sizeof(uint8_t), sz, fp);
+    fclose(fp);
+
+    if (read_size != mem->max_ram_banks_num * 0x2000) {
+        LOG_ERROR("Size mismatch between savfile and cartridge RAM\n");
+        return false;
+    }
+    return true;
+}
+
+bool write_battery(char *savfile, gb_memory *mem)
+{
+    if (!savfile)
+        return false;
+
+    gb_memory_ram_flush(mem);
+
+    FILE *fp = fopen(savfile, "wb");
+    if (!fp) {
+        LOG_ERROR("Failed to open file %s\n", savfile);
+        return false;
+    }
+
+    size_t ramsize = mem->max_ram_banks_num * 0x2000;
+    size_t write_size = fwrite(mem->ram_banks, sizeof(uint8_t), ramsize, fp);
+    fclose(fp);
+
+    if (write_size != ramsize) {
+        LOG_ERROR("Size mismatch between savfile and cartridge RAM\n");
+        return false;
+    }
+
+    return true;
+}

--- a/src/save.h
+++ b/src/save.h
@@ -1,0 +1,11 @@
+#ifndef JITBOY_SAV_H
+#define JITBOY_SAV_H
+
+/* Most Game Boy cartridges that allow games to be saved contain a small
+ * internal battery to store the save states. We emulate how it works
+ * on jitboy.
+ */
+bool read_battery(char *savfile, gb_memory *mem);
+bool write_battery(char *savfile, gb_memory *mem);
+
+#endif


### PR DESCRIPTION
Most Game Boy cartridges that allow games to be saved contain a small internal battery to store the save states. If we can emulate the feature, games like Pokémon would be experienced better!

The key of game-saving In Game Boy related to ram banks. One of the ram banks in cartridges will be switched in address space 0xA000 - 0xBFFF, so Game Boy can restore its state accordingly. Since the ram banks switching in jitboy was already well-implemented, we don't have to worry too much about it. What we should do to save the state in our emulator is coping all of the ram banks into a file,  and reversing the process to restore the ram banks. There's only one thing we should take care of it: how jitboy "switch" the ram banks to 0xA000 - 0xBFFF is creating a copy, so we need to flush it back when doing state saving.

Known issue: jitboy now define `MAX_RAM_BANKS` to 4, which may not be the true maximum number of ram banks in Game Boy. So the cartridges contain more than 32KBytes ram will have some problem in the current patch.
