### PR TITLE
Keep correcting the instructions that make errors on gbit

### DIFF
--- a/src/dasm_macros.inc
+++ b/src/dasm_macros.inc
@@ -1,9 +1,17 @@
 |.macro clean_flag, mask
-    | push rax  
-    | lahf 
-    | and ah, ~mask 
-    | sahf 
-    | pop rax    
+    | push rax
+    | lahf
+    | and ah, ~mask
+    | sahf
+    | pop rax
+|.endmacro
+
+|.macro set_flag, mask
+    | push rax
+    | lahf
+    | or ah, mask
+    | sahf
+    | pop rax
 |.endmacro
 
 |.macro write_byte, addr, value

--- a/src/emit.dasc
+++ b/src/emit.dasc
@@ -573,8 +573,8 @@ static bool inst_add16(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
         | pushfq
         | pop tmp1
         | and tmp1b, 0x40
-        | push tmp1       
-        
+        | push tmp1 
+
         | and xH, 0xff
         | and xL, 0xff
         | mov tmp2, xH
@@ -625,7 +625,7 @@ static bool inst_add16(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
         | pop tmp1
         /* pop for zero flag status */
         | pop tmp2
-        
+ 
         | and tmp1b, ~0x50
         | or tmp1b, tmp2b
         | or tmp1b, tmp3b
@@ -637,9 +637,27 @@ static bool inst_add16(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
             LOG_ERROR("Invalid 2nd operand to ADD16\n");
             return false;
         }
+        /* calculate for carry flag */
+        | mov tmp1w, SP
+        | and tmp1, 0xff
+        | mov tmp2w, inst->args[1]
+        | and tmp2, 0xff
+        | add tmp1, tmp2
+        | and tmp1, 0x100
+        | shr tmp1, 8
+
+        /* for H flag, this instruction will deal with it */
         | add SP, (int8_t)inst->args[1]
-        /* set zero flag to zero */
-        | clean_flag 0x40
+
+        /* for Z flag, set to zero
+         * for C flag, set according to tmp1 we calculated before
+         */
+        | pushfq
+        | pop tmp2
+        | and tmp2, ~0x41
+        | or tmp2, tmp1
+        | push tmp2
+        | popfq
 
         break;
     default:

--- a/src/emit.dasc
+++ b/src/emit.dasc
@@ -692,6 +692,8 @@ static bool inst_cpl(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
     | print "CPL"
     | mov byte state->f_subtract, 1
     | not A
+    /* set H flag */
+    | set_flag 0x10
     return true;
 }
 

--- a/src/emit.dasc
+++ b/src/emit.dasc
@@ -718,6 +718,8 @@ static bool inst_and(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
     | print "AND"
     | mov byte state->f_subtract, 0
     | inst and, inst->op1, inst->op2
+    /* set H flag */
+    | set_flag 0x10
     *cycles += inst->cycles;
     return true;
 }

--- a/src/emit.dasc
+++ b/src/emit.dasc
@@ -776,6 +776,8 @@ static bool inst_ccf(dasm_State **Dst, gbz80_inst *inst, uint64_t *cycles)
     | print "CCF"
     | mov byte state->f_subtract, 0
     | cmc 
+    /* clean H flag */
+    | clean_flag 0x10
     *cycles += inst->cycles;
     return true;
 }


### PR DESCRIPTION
Keep correcting the instructions that make errors on gbit. Also, some unintended spaces are found and removed.

Some instruction just has small error:
* For `AND`, always set H flag to 1
* For `CPL`, always set H flag to 1
* For `CCF`, always clean H flag to 1

For `ADD16`, although I have made some changes in the previous PR, it still leaves some errors there. The error happens when `ADD16` is used for adding the stack pointer. The status flag won't update correctly. After my fix, the instruction can now work correctly and pass gbit. Only one thing to notice here: I think there should exist some effective way to update C flag, although I have no good idea now.
