### PR TITLE
Fix build target order to get submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ JITBOY_OBJS = main.o
 JITBOY_OBJS += $(OBJS)
 JITBOY_OBJS := $(addprefix $(OUT)/, $(JITBOY_OBJS))
 
-INSTR_TEST_OBJS = instr_test.o tester.o inputstate.o ref_cpu.o disassembler.o
+INSTR_TEST_OBJS = tester.o inputstate.o ref_cpu.o disassembler.o instr_test.o
 INSTR_TEST_OBJS += $(OBJS)
 INSTR_TEST_OBJS := $(addprefix instr-test-, $(INSTR_TEST_OBJS))
 INSTR_TEST_OBJS := $(addprefix $(OUT)/, $(INSTR_TEST_OBJS))


### PR DESCRIPTION
`instr_test.o` should be built after those gbit targets, or Makefile won't clone the gbit repository. I'm sorry for so many careless mistakes.