### PR TITLE
Fix exploitable heap out-of-bound access

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -10,7 +10,7 @@
 #include "memory.h"
 
 #define MAX_ROM_BANKS 256
-#define MAX_RAM_BANKS 4
+#define MAX_RAM_BANKS 16
 
 typedef struct {
     gb_state state;

--- a/src/memory.c
+++ b/src/memory.c
@@ -292,4 +292,9 @@ void dump_header_info(gb_memory *mem)
 
     /* recording header info for some later usage */
     mem->max_ram_banks_num = ram_size == 2 ? 1 : ram_size / 8;
+    if (mem->max_ram_banks_num > MAX_RAM_BANKS) {
+        LOG_ERROR("unsupported RAM bank count (%i), hard capped to %i banks",
+                  mem->max_ram_banks_num, MAX_RAM_BANKS);
+        mem->max_ram_banks_num = MAX_RAM_BANKS;
+    }
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -152,7 +152,8 @@ void gb_memory_write(gb_state *state, uint64_t addr, uint64_t value)
         case MBC5_RAM_BAT:
         case MBC5:
             if (addr >= 0x4000) {
-                gb_memory_change_ram_bank(state->mem, value);
+                int bank = (value & 0xf);
+                gb_memory_change_ram_bank(state->mem, bank);
             } else if (addr >= 0x2000) {
                 int bank = value;
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -133,10 +133,13 @@ void gb_memory_write(gb_state *state, uint64_t addr, uint64_t value)
             if (addr >= 0x6000) {
                 gb_memory_update_rtc_time(state->mem, value);
             } else if (addr >= 0x4000) {
-                if (value <= 4)
+                if (value < 4) {
                     gb_memory_change_ram_bank(state->mem, value);
-                else
+                } else if (value >= 8 && value < 13) {
                     gb_memory_access_rtc(state->mem, value);
+                } else {
+                    LOG_DEBUG("failed to change ram bank to %i\n", value);
+                }
             } else if (addr >= 0x2000) {
                 int bank = (value & 0x7f);
                 if (bank == 0)

--- a/src/save.c
+++ b/src/save.c
@@ -16,18 +16,26 @@ bool read_battery(char *savfile, gb_memory *mem)
         return false;
     }
 
-    /* get file size and allocate size accordingly */
+    /* get file size */
     fseek(fp, 0, SEEK_END);
     size_t sz = ftell(fp) * sizeof(uint8_t);
     rewind(fp);
 
-    size_t read_size = fread(mem->ram_banks, sizeof(uint8_t), sz, fp);
-    fclose(fp);
+    size_t ramsize = mem->max_ram_banks_num * 0x2000;
 
-    if (read_size != mem->max_ram_banks_num * 0x2000) {
+    if (sz != ramsize) {
         LOG_ERROR("Size mismatch between savfile and cartridge RAM\n");
         return false;
     }
+
+    size_t read_size = fread(mem->ram_banks, sizeof(uint8_t), sz, fp);
+    fclose(fp);
+
+    if (read_size != ramsize) {
+        LOG_ERROR("Short read from savfile\n");
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Fix #25 

Fixed two vulnerabilities that could lead to arbitrary code execution:
- (almost) arbitrary heap r/w in MBC3 and MBC5 cartridge RAM bank switch handler
- heap buffer overflow while loading Gameboy save file (kudos to @u1f383)