### PR TITLE
Add more CLI options

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -10,7 +10,11 @@ void free_block(gb_block *block)
     munmap(block->mem, block->size);
 }
 
-bool init_vm(gb_vm *vm, const char *filename, int opt_level, bool init_io)
+bool init_vm(gb_vm *vm,
+             const char *filename,
+             int opt_level,
+             int scale,
+             bool init_io)
 {
     if (!gb_memory_init(&vm->memory, filename))
         return false;
@@ -90,7 +94,7 @@ bool init_vm(gb_vm *vm, const char *filename, int opt_level, bool init_io)
 
     if (init_io) {
         /* both audio and lcd will be initialized if init_io is true*/
-        if (!init_window(&vm->lcd))
+        if (!init_window(&vm->lcd, scale))
             return false;
 
         vm->draw_frame = true;

--- a/src/core.c
+++ b/src/core.c
@@ -14,7 +14,8 @@ bool init_vm(gb_vm *vm,
              const char *filename,
              int opt_level,
              int scale,
-             bool init_io)
+             bool init_render,
+             bool init_sound)
 {
     if (!gb_memory_init(&vm->memory, filename))
         return false;
@@ -92,7 +93,7 @@ bool init_vm(gb_vm *vm,
     if (!read_battery(vm->memory.savname, &vm->memory))
         LOG_ERROR("Fail to read battery\n");
 
-    if (init_io) {
+    if (init_render) {
         /* both audio and lcd will be initialized if init_io is true*/
         if (!init_window(&vm->lcd, scale))
             return false;
@@ -104,7 +105,8 @@ bool init_vm(gb_vm *vm,
         vm->frame_cnt = 0;
 
         vm->opt_level = opt_level;
-
+    }
+    if (init_sound) {
         audio_init(&vm->audio, &vm->memory);
     }
 

--- a/src/core.c
+++ b/src/core.c
@@ -111,7 +111,7 @@ bool init_vm(gb_vm *vm,
     return true;
 }
 
-bool run_vm(gb_vm *vm)
+bool run_vm(gb_vm *vm, bool turbo)
 {
     uint16_t prev_pc = vm->state.last_pc;
     vm->state.last_pc = vm->state.pc;
@@ -185,8 +185,11 @@ bool run_vm(gb_vm *vm)
             if (vm->memory.mem[0xff44] == 144) {
                 if (vm->draw_frame) {
                     unsigned time = SDL_GetTicks();
-                    if (!SDL_TICKS_PASSED(time, vm->next_frame_time)) {
-                        SDL_Delay(vm->next_frame_time - time);
+                    if (!turbo) {
+                        if (!SDL_TICKS_PASSED(time, vm->next_frame_time)) {
+                            SDL_Delay(vm->next_frame_time - time);
+                        }
+                        vm->next_frame_time += 17; /* 17ms until next frame */
                     }
 
                     vm->time_busy += time - vm->last_time;
@@ -201,7 +204,6 @@ bool run_vm(gb_vm *vm)
                         vm->time_busy = 0;
                     }
 
-                    vm->next_frame_time += 17; /* 17ms until next frame */
                     SDL_CondBroadcast(vm->lcd.vblank_cond);
                     vm->draw_frame = false;
                 }

--- a/src/core.h
+++ b/src/core.h
@@ -31,8 +31,12 @@ typedef struct {
 
 void free_block(gb_block *block);
 
-bool init_vm(gb_vm *vm, const char *filename, int opt_level, bool init_io);
 bool run_vm(gb_vm *vm);
+bool init_vm(gb_vm *vm,
+             const char *filename,
+             int opt_level,
+             int scale,
+             bool init_io);
 bool free_vm(gb_vm *vm);
 
 #endif

--- a/src/core.h
+++ b/src/core.h
@@ -35,7 +35,8 @@ bool init_vm(gb_vm *vm,
              const char *filename,
              int opt_level,
              int scale,
-             bool init_io);
+             bool init_render,
+             bool init_sound);
 bool run_vm(gb_vm *vm, bool turbo);
 bool free_vm(gb_vm *vm);
 

--- a/src/core.h
+++ b/src/core.h
@@ -31,12 +31,12 @@ typedef struct {
 
 void free_block(gb_block *block);
 
-bool run_vm(gb_vm *vm);
 bool init_vm(gb_vm *vm,
              const char *filename,
              int opt_level,
              int scale,
              bool init_io);
+bool run_vm(gb_vm *vm, bool turbo);
 bool free_vm(gb_vm *vm);
 
 #endif

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -181,11 +181,13 @@ static int render_thread_function(void *ptr)
     return 0;
 }
 
-bool init_window(gb_lcd *lcd)
+bool init_window(gb_lcd *lcd, int scale)
 {
     SDL_Init(SDL_INIT_VIDEO);
+    int width = 160 * scale;
+    int height = 144 * scale;
     lcd->win = SDL_CreateWindow("jitboy", SDL_WINDOWPOS_UNDEFINED,
-                                SDL_WINDOWPOS_UNDEFINED, 160 * 3, 144 * 3,
+                                SDL_WINDOWPOS_UNDEFINED, width, height,
                                 SDL_WINDOW_OPENGL);
     if (!lcd->win) {
         LOG_ERROR("Window could not be created! SDL_Error: %s\n",

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -13,7 +13,7 @@ typedef struct {
     bool fullscreen;
 } gb_lcd;
 
-bool init_window(gb_lcd *lcd);
+bool init_window(gb_lcd *lcd, int scale);
 void deinit_window(gb_lcd *lcd);
 void update_line(uint8_t *mem);
 void toggle_fullscreen(gb_lcd *lcd);

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,8 @@ static void usage(const char *exe)
         "Usage: %s [OPTIONS]\n"
         "Options:\n"
         "  -O, --opt-level=LEVEL   Set the optimization level (default: 0)\n"
-        "  -s, --scale=SCALE       Set the scale of the window (default: 3)\n",
+        "  -s, --scale=SCALE       Set the scale of the window (default: 3)\n"
+        "  -t, --turbo             Run in turbo mode\n",
         exe);
 }
 
@@ -50,19 +51,26 @@ int main(int argc, char *argv[])
 
     int opt_level = 0;
     int scale = 3;
+    int turbo = false;
+
     int c;
     const struct option long_options[] = {
         {"opt-level", required_argument, NULL, 'O'},
         {"scale", required_argument, NULL, 's'},
+        {"turbo", no_argument, NULL, 't'},
         {NULL, 0, NULL, 0}  // Terminating element
     };
-    while ((c = getopt_long(argc, argv, "O:s:", long_options, NULL)) != -1) {
+
+    while ((c = getopt_long(argc, argv, "O:s:t", long_options, NULL)) != -1) {
         switch (c) {
         case 'O':
             sscanf(optarg, "%i", &opt_level);
             break;
         case 's':
             sscanf(optarg, "%i", &scale);
+            break;
+        case 't':
+            turbo = true;
             break;
         case '?':
         default:
@@ -96,7 +104,7 @@ int main(int argc, char *argv[])
     SDL_Event evt;
 
     /* start emulation */
-    while (run_vm(vm)) {
+    while (run_vm(vm, turbo)) {
         while (SDL_PollEvent(&evt)) {
             switch (evt.type) {
             case SDL_KEYUP:

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,4 @@
+#include <getopt.h>
 #include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -7,7 +8,11 @@
 
 static void usage(const char *exe)
 {
-    printf("usage: %s [-O LEVEL] file.gb\n", exe);
+    printf(
+        "Usage: %s [OPTIONS]\n"
+        "Options:\n"
+        "  -O, --opt-level=LEVEL   Set the optimization level (default: 0)\n",
+        exe);
 }
 
 static void banner()
@@ -44,7 +49,11 @@ int main(int argc, char *argv[])
 
     int opt_level = 0;
     int c;
-    while ((c = getopt(argc, argv, "O:")) != -1) {
+    const struct option long_options[] = {
+        {"opt-level", required_argument, NULL, 'O'},
+        {NULL, 0, NULL, 0}  // Terminating element
+    };
+    while ((c = getopt_long(argc, argv, "O:", long_options, NULL)) != -1) {
         switch (c) {
         case 'O':
             sscanf(optarg, "%i", &opt_level);

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,8 @@ static void usage(const char *exe)
     printf(
         "Usage: %s [OPTIONS]\n"
         "Options:\n"
-        "  -O, --opt-level=LEVEL   Set the optimization level (default: 0)\n",
+        "  -O, --opt-level=LEVEL   Set the optimization level (default: 0)\n"
+        "  -s, --scale=SCALE       Set the scale of the window (default: 3)\n",
         exe);
 }
 
@@ -48,15 +49,20 @@ int main(int argc, char *argv[])
     }
 
     int opt_level = 0;
+    int scale = 3;
     int c;
     const struct option long_options[] = {
         {"opt-level", required_argument, NULL, 'O'},
+        {"scale", required_argument, NULL, 's'},
         {NULL, 0, NULL, 0}  // Terminating element
     };
-    while ((c = getopt_long(argc, argv, "O:", long_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "O:s:", long_options, NULL)) != -1) {
         switch (c) {
         case 'O':
             sscanf(optarg, "%i", &opt_level);
+            break;
+        case 's':
+            sscanf(optarg, "%i", &scale);
             break;
         case '?':
         default:
@@ -77,7 +83,7 @@ int main(int argc, char *argv[])
 
     /* initialize memory */
     gb_vm *vm = malloc(sizeof(gb_vm));
-    if (!init_vm(vm, argv[optind], opt_level, true)) {
+    if (!init_vm(vm, argv[optind], opt_level, scale, true)) {
         LOG_ERROR("Fail to initialize\n");
         exit(1);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,8 @@ static void usage(const char *exe)
         "Options:\n"
         "  -O, --opt-level=LEVEL   Set the optimization level (default: 0)\n"
         "  -s, --scale=SCALE       Set the scale of the window (default: 3)\n"
-        "  -t, --turbo             Run in turbo mode\n",
+        "  -t, --turbo             Run in turbo mode\n"
+        "      --no-sound          Disable audio initialization\n",
         exe);
 }
 
@@ -52,12 +53,14 @@ int main(int argc, char *argv[])
     int opt_level = 0;
     int scale = 3;
     int turbo = false;
+    int init_sound = true;
 
     int c;
     const struct option long_options[] = {
         {"opt-level", required_argument, NULL, 'O'},
         {"scale", required_argument, NULL, 's'},
         {"turbo", no_argument, NULL, 't'},
+        {"no-sound", no_argument, NULL, 'a'},
         {NULL, 0, NULL, 0}  // Terminating element
     };
 
@@ -71,6 +74,9 @@ int main(int argc, char *argv[])
             break;
         case 't':
             turbo = true;
+            break;
+        case 'a':
+            init_sound = false;
             break;
         case '?':
         default:
@@ -91,7 +97,7 @@ int main(int argc, char *argv[])
 
     /* initialize memory */
     gb_vm *vm = malloc(sizeof(gb_vm));
-    if (!init_vm(vm, argv[optind], opt_level, scale, true)) {
+    if (!init_vm(vm, argv[optind], opt_level, scale, true, init_sound)) {
         LOG_ERROR("Fail to initialize\n");
         exit(1);
     }

--- a/tests/instr_test.c
+++ b/tests/instr_test.c
@@ -37,7 +37,7 @@ static void gbz80_init(size_t tester_instruction_mem_size,
     instruction_mem = tester_instruction_mem;
 
     vm = malloc(sizeof(gb_vm));
-    if (!init_vm(vm, NULL, 0, false)) {
+    if (!init_vm(vm, NULL, 0, 0, false)) {
         LOG_ERROR("Fail to initialize\n");
         exit(1);
     }

--- a/tests/instr_test.c
+++ b/tests/instr_test.c
@@ -37,7 +37,7 @@ static void gbz80_init(size_t tester_instruction_mem_size,
     instruction_mem = tester_instruction_mem;
 
     vm = malloc(sizeof(gb_vm));
-    if (!init_vm(vm, NULL, 0, 0, false)) {
+    if (!init_vm(vm, NULL, 0, 0, false, false)) {
         LOG_ERROR("Fail to initialize\n");
         exit(1);
     }


### PR DESCRIPTION
I was trying to measure the performance of JitBoy, and also integrate it into [daid/GBEmulatorShootout](https://github.com/daid/GBEmulatorShootout). In the end I failed to integrate it (I could not get WSL to work on github actions), but I added some changes that may be worth upstreaming.

I added these CLI options:

- `turbo`: disables the timing delay between frames in `run_vm`.
- `scale`: controls the size of the screen. I was using it to increase the performance, but I don't think this is making any difference.
- `no-sound`: disables SDL audio initialization. I am running the emulator in WSL, and the emulator was crashing due to the lack of an audio device.

Enabling `turbo` or `no-sound` may break the APU emulation because the `audio_callback` is the only thing driving it. But I don't think the emulation was that precise to begin with, and fixing this would need a lot more work.